### PR TITLE
Add Travis build for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,16 @@ language: R
 sudo: false
 cache: packages
 
+matrix:
+  include:
+    - os: linux
+      r: release
+      env: R_COVR=run-covr
+    - os: linux
+      r: devel
+      warnings_are_errors: false
+    - os: osx
+      r: release
+
 after_success:
-  - Rscript -e 'covr::codecov()'
+  - test $R_COVR && Rscript -e "covr::codecov()"

--- a/R/setup_project.R
+++ b/R/setup_project.R
@@ -36,8 +36,8 @@ setup_project <-
                 utils::capture.output(use_package('rmarkdown'))
                 include_readmes()
                 include_r_files()
-                use_git()
-                if (is.null(git2r::config()$user.name) & is.null(git2r::config()$global$user.name)) {
+                git_config <- git2r::config()$global
+                if (is.null(git_config$user.name) || is.null(git_config$user.email)) {
                     warning(
                         "Please set your user.name and user.email in your Git config.",
                         " Use git2r::config(user.name = 'name', user.email = 'email').",


### PR DESCRIPTION
xref: #100 

I updated the Travis configuration to run 3 separate builds:

1. Release version of R on Linux (this is the current default)
1. Devel version of R on Linux (to anticipate any issues with submission to CRAN)
1. Release version of R on macOS

Furthermore, `covr::codecov` is only run for the first build.

Something strange is going on though. The builds should be failing because the the user.name and user.email have not been set, but the builds on my fork still passed!

https://travis-ci.org/jdblischak/prodigenr/builds/425341573

I realized that `use_git()` doesn't throw an error during `R CMD check` because it only tries to commit the files if `interactive()` is `TRUE`. I also updated the check introduced in commit 12f4c0ffa8d9c70dfe02f86faac0d4c1c0672613 to throw a warning of either user.name or user.email is not set. However, for some reason during the Travis build the warning is not triggered, even though I can trigger it locally by temporarily deleting my `.gitconfig` file and running `devtools::test()`.

https://codecov.io/gh/jdblischak/prodigenr/src/travis-osx/R/setup_project.R#L41

Any idea what is going on?